### PR TITLE
Fix call on-error when failed window.execCommand

### DIFF
--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -24,7 +24,9 @@ angular.module('angular-clipboard', [])
                     selection.removeAllRanges();
                     node.select();
 
-                    $document[0].execCommand('copy');
+                    if(!$document[0].execCommand('copy')) {
+                      throw('failure copy');
+                    }
                     selection.removeAllRanges();
 
                     // Reset inline style

--- a/test/angular-clipboard.spec.js
+++ b/test/angular-clipboard.spec.js
@@ -17,12 +17,19 @@ describe('angular-clipboard', function () {
     }));
 
     it('should invoke success callback', function () {
+        spyOn(document, 'execCommand').and.returnValue(true);
         elm.triggerHandler('click');
         expect(scope.success).toHaveBeenCalled();
     });
 
     it('should invoke fail callback', function () {
         spyOn(document.body, 'appendChild').and.throwError('fake');
+        elm.triggerHandler('click');
+        expect(scope.fail).toHaveBeenCalled();
+    });
+
+    it('should invoke fail callback', function () {
+        spyOn(document, 'execCommand').and.returnValue(false);
         elm.triggerHandler('click');
         expect(scope.fail).toHaveBeenCalled();
     });


### PR DESCRIPTION
'on-copied' is called at present. Even if window.execCommand is failed, When I try demo on safari