### PR TITLE
Prevent page scrolling on copy.

### DIFF
--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -27,7 +27,7 @@ return angular.module('angular-clipboard', [])
                 var selection = $document[0].getSelection();
                 selection.removeAllRanges();
 
-                var x = window.scrollX, y = window.scrollY;
+                var x = window.pageXOffset, y = window.pageYOffset;
                 node.select();
                 window.scrollTo(x, y);
 

--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -26,7 +26,10 @@ return angular.module('angular-clipboard', [])
 
                 var selection = $document[0].getSelection();
                 selection.removeAllRanges();
+
+                var x = window.scrollX, y = window.scrollY;
                 node.select();
+                window.scrollTo(x, y);
 
                 if(!$document[0].execCommand('copy')) {
                     throw('failure copy');


### PR DESCRIPTION
On larger pages the scrollbar will jump to the hidden node, i.e. the end of the document on node.select() - at least in IE 11. You can try it at https://plnkr.co/JMOnatFAlWrh0R53FuTu.

The fix is pretty straight-forward and working well for me.