### PR TITLE
Update angular-clipboard.js

### DIFF
--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -57,7 +57,7 @@ return angular.module('angular-clipboard', [])
                 onCopied: '&',
                 onError: '&',
                 text: '=',
-                supported: '='
+                supported: '=?'
             },
             link: function (scope, element) {
                 scope.supported = clipboard.supported;


### PR DESCRIPTION
This is now throwing errors in tests as the property must be assignable on compile. 
http://errors.angularjs.org/1.5.5/$compile/nonassign?p0=undefined&p1=supported&p2=clipboard 

It would suck to be forced to include an unnecessary property on all scopes if I don't need it, and the README states that it is optional.