### PR TITLE
5/6/2016 provide safari select support

### DIFF
--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -29,6 +29,8 @@ return angular.module('angular-clipboard', [])
                 node.select();
 
                 if(!$document[0].execCommand('copy')) {
+                    node.focus();
+                    node.setSelectionRange(0, node.textContent.length);
                     throw('failure copy');
                 }
                 selection.removeAllRanges();


### PR DESCRIPTION
1. focus first
2. setSelectionRange

P.S
Hello, 
This patch will allow user to at least select in safari.
Although safari can not do execCommand 'Copy'. It's still support getSelection().
Once it's select it should be able to show a tooltip give user a hint to press : press ⌘-C to Copy onError event