### PR TITLE
Add license to bower file.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "dependencies": {
         "angular": "*"
     },
+    "license": "MIT",
     "ignore": [
         "demo",
         "test",


### PR DESCRIPTION
The bower file didn't have the MIT license mentioned in it. Discovered while I was running bower-license.