### PR TITLE
add fn property which return the text for copy command

### DIFF
--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -65,7 +65,11 @@ return angular.module('angular-clipboard', [])
 
                 element.on('click', function (event) {
                     try {
-                        clipboard.copyText(scope.text, element[0]);
+                        if (scope.fn) {
+                            clipboard.copyText(scope.fn(), element[0]);
+                        }else{
+                            clipboard.copyText(scope.text, element[0]);
+                        }
                         if (angular.isFunction(scope.onCopied)) {
                             scope.$evalAsync(scope.onCopied());
                         }

--- a/test/angular-clipboard.spec.js
+++ b/test/angular-clipboard.spec.js
@@ -50,4 +50,51 @@ describe('angular-clipboard', function () {
     it('should feature detect and set supported', function () {
         expect(scope.supported).toEqual(true);
     });
+
+    describe('when the text to copy is provide by fn property', function() {
+        beforeEach(angular.mock.inject(function ($rootScope, $compile) {
+            scope = $rootScope;
+            elm = $compile('<button clipboard supported="supported" text="textToCopy" on-copied="success()" on-error="fail(err)">Copy</button>')(scope);
+
+            scope.supported = undefined;
+            scope.textToCopy = function(){return 'Copy me!'; };
+            scope.copied = false;
+            scope.success = function () {scope.copied = true;};
+            scope.fail = function (err) {};
+            scope.$digest();
+
+            spyOn(scope, 'success').and.callThrough();
+            spyOn(scope, 'fail');
+        }));
+
+        it('should invoke success callback after successful execCommand', function () {
+            spyOn(document, 'execCommand').and.returnValue(true);
+            elm.triggerHandler('click');
+            expect(scope.success).toHaveBeenCalled();
+        });
+
+        it('should invoke fail callback on error in execCommand', function () {
+            spyOn(document, 'execCommand').and.returnValue(false);
+            elm.triggerHandler('click');
+            expect(scope.fail).toHaveBeenCalledWith('failure copy');
+        });
+
+        it('should invoke fail callback on invalid child element', function () {
+            spyOn(document.body, 'appendChild').and.throwError('fake');
+            elm.triggerHandler('click');
+            expect(scope.fail).toHaveBeenCalled();
+        });
+
+        it('should be caught by angular\'s digest cycle', function () {
+            spyOn(document, 'execCommand').and.returnValue(true);
+            elm.triggerHandler('click');
+            expect(scope.copied).toEqual(true);
+        });
+
+        it('should export/return angular module', function () {
+            expect(window.angularClipboard).toBeDefined();
+            expect(window.angularClipboard.name).toEqual('angular-clipboard');
+        });
+
+    });
 });


### PR DESCRIPTION
I add a property fn when the text for copy is returned by function and not exact from a string on model.

The aproach on test maybe not to be the better, but I think valid.
