### PR TITLE
Set global default for success/error callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+.DS_Store

--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -10,6 +10,23 @@
 }(this, function (angular) {
 
 return angular.module('angular-clipboard', [])
+    .provider('angularClipboardProvider', function () {
+        this.options = {
+            onCopiedDefaultCallback: false,
+            onErrorDefaultCallback: false
+        };
+        this.configure = function (options) {
+            angular.extend(this.options, options);
+        };
+        this.$get = function() {
+            /*return {
+                defaultOnCopied: this.options.onCopiedDefaultCallback,
+                defaultOnError: this.options.onErrorDefaultCallback,
+            };*/
+            return this;
+        };
+        //return this;
+    })
     .factory('clipboard', ['$document', '$window', function ($document, $window) {
         function createNode(text, context) {
             var node = $document[0].createElement('textarea');
@@ -51,7 +68,7 @@ return angular.module('angular-clipboard', [])
             supported: 'queryCommandSupported' in $document[0] && $document[0].queryCommandSupported('copy')
         };
     }])
-    .directive('clipboard', ['clipboard', function (clipboard) {
+    .directive('clipboard', ['clipboard', 'angularClipboardProvider', function (clipboard, angularClipboardProvider) {
         return {
             restrict: 'A',
             scope: {
@@ -62,6 +79,10 @@ return angular.module('angular-clipboard', [])
             },
             link: function (scope, element) {
                 scope.supported = clipboard.supported;
+
+                if (!angular.isFunction(scope.onCopied) && angular.isFunction(angularClipboardProvider.defaultOnCopied)) {
+                    scope.onCopied = angularClipboardProvider.defaultOnCopied;
+                }
 
                 element.on('click', function (event) {
                     try {

--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -23,7 +23,6 @@ return angular.module('angular-clipboard', [])
                 defaultOnCopied: this.options.onCopiedDefaultCallback,
                 defaultOnError: this.options.onErrorDefaultCallback,
             };
-            return this;
         };
         return this;
     })

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -22,6 +22,14 @@
         <script>
             var demoApp = angular.module('demoApp', ['angular-clipboard']);
 
+            demoApp.config(function(angularClipboardProvider) {
+                angularClipboardProvider.configure({
+                    onCopiedDefaultCallback: function(){
+                        console.log("Copied like a pro!");
+                    }
+                })
+            });
+
             demoApp.controller('DemoCtrl', ['$scope', function ($scope) {
                 $scope.supported = false;
 

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -10,7 +10,7 @@
 
         <p>
             <textarea ng-model="textToCopy" rows="5" cols="30"></textarea><br />
-            <button clipboard supported="supported" text="textToCopy" on-copied="success()" on-error="fail(err)">Copy</button>
+            <button clipboard supported="supported" text="textToCopy"  on-error="fail(err)">Copy</button>
         </p>
 
         <p>
@@ -22,13 +22,13 @@
         <script>
             var demoApp = angular.module('demoApp', ['angular-clipboard']);
 
-            demoApp.config(function(angularClipboardProvider) {
+            demoApp.config([ "angularClipboardProvider", function(angularClipboardProvider) {
                 angularClipboardProvider.configure({
                     onCopiedDefaultCallback: function(){
                         console.log("Copied like a pro!");
                     }
                 })
-            });
+            }]);
 
             demoApp.controller('DemoCtrl', ['$scope', function ($scope) {
                 $scope.supported = false;


### PR DESCRIPTION
This feature allows you to set default callbacks for success/error.
Setting the callback with the directive attributes on-success and on-error will override the global default.
I'm not sure this implementation of the feature is of best practice.
Please let me know if you have better ideas or any comments on the code.