### PR TITLE
fix(firefox): clean up on error when copy command fails

### DIFF
--- a/angular-clipboard.js
+++ b/angular-clipboard.js
@@ -40,10 +40,13 @@ return angular.module('angular-clipboard', [])
                 // This makes it work on Mobile Safari
                 node.setSelectionRange(0, 999999);
 
-                if(!$document[0].execCommand('copy')) {
-                    throw('failure copy');
+                try {
+                    if(!$document[0].execCommand('copy')) {
+                        throw('failure copy');
+                    }
+                } finally {
+                    selection.removeAllRanges();
                 }
-                selection.removeAllRanges();
             } finally {
                 // Reset inline style
                 $document[0].body.style.webkitUserSelect = '';


### PR DESCRIPTION
On firefox, there is a weird behaviour if you don't call the clean up method removeAllRanges on the textarea.
For example, key up is not called, which generally you want to bind an event on cut/paste.